### PR TITLE
Fix potential warning when deal with bad exif

### DIFF
--- a/Zebra_Image.php
+++ b/Zebra_Image.php
@@ -1542,7 +1542,7 @@ class Zebra_Image {
                 return false;
 
             // if "exif_read_data" function is available, EXIF information is available, orientation information is available and orientation needs fixing
-            } elseif (($exif = exif_read_data($this->source_path)) && isset($exif['Orientation']) && in_array($exif['Orientation'], array(3, 6, 8))) {
+            } elseif (($exif = @exif_read_data($this->source_path)) && isset($exif['Orientation']) && in_array($exif['Orientation'], array(3, 6, 8))) {
 
                 // fix the orientation
                 switch ($exif['Orientation']) {


### PR DESCRIPTION
Fixes errors like "Warning: exif_read_data: Incorrect APP1 Exif Identifier Code"
More info:
https://stackoverflow.com/q/8106683/1203805
https://www.drupal.org/node/556970